### PR TITLE
update _read_px_size()

### DIFF
--- a/cellocity/channel.py
+++ b/cellocity/channel.py
@@ -179,7 +179,7 @@ class Channel(object):
                 return px_size_um
     
             elif (re.search(gamma_regex, version) != None):
-                px_size_um = self.tif.micromanager_metadata['PixelSize_um']
+                px_size_um = self.tif.micromanager_metadata['PixelSizeUm']
     
                 return px_size_um
     


### PR DESCRIPTION
They also changed the key name to PixelSizeUm. This edit works on my mm-2.0gamma files, but might break things for old gamma releases?